### PR TITLE
convert day number into date field

### DIFF
--- a/macros/get_demo_duration.sql
+++ b/macros/get_demo_duration.sql
@@ -1,0 +1,18 @@
+{% macro get_demo_duration() %}
+
+    {% set get_max_day %}
+        select max(day) from {{ source('complete_journey', 'transaction_data')}}
+    {% endset %}
+
+    {% set results = run_query(get_max_day) %}
+
+    {% if execute %}
+        {# Return the first column #}
+        {% set result = results.columns[0].values()[0] %}
+    {% else %}
+        {% set result = [] %}
+    {% endif %}
+
+    {{ return(result) }}
+
+{% endmacro %}

--- a/models/marts/mart_transactions.sql
+++ b/models/marts/mart_transactions.sql
@@ -1,13 +1,9 @@
 {{ config(
     materialized='table',
     partition_by={
-      "field": "day_number",
-      "data_type": "int64",
-      "range": {
-        "start": 0,
-        "end": 719,
-        "interval": 10
-      }
+      "field": "transaction_date",
+      "data_type": "date",
+      "granularity": "day"
     },
     cluster_by = ["store_id", "department", "brand", "commodity_description"],
 )}}
@@ -42,7 +38,7 @@ final as (
 
         transactions.household_id,
         transactions.basket_id,
-        transactions.day_number,
+        transactions.transaction_date,
         transactions.product_id,
         transactions.quantity,
         transactions.sales_value,

--- a/models/staging/complete_journey/base/base_complete_journey__transaction_data.sql
+++ b/models/staging/complete_journey/base/base_complete_journey__transaction_data.sql
@@ -9,13 +9,14 @@ renamed as (
     select
         household_key as household_id,
         basket_id,
-        day as day_number,
+        -- day as day_number,
+        date_sub(current_date(), interval ({{ get_demo_duration() }} - day) day) as transaction_date,
         product_id,
         quantity,
         sales_value,
         store_id,
         retail_disc as retail_discount,
-        trans_time as transaction_time,
+        time(cast(floor(trans_time/100) as int64), MOD(trans_time, 100), 00) as transaction_time,
         week_no as week_number,
         coupon_disc as coupon_discount,
         coupon_match_disc as coupon_match_discount

--- a/models/staging/complete_journey/stg_complete_journey__transactions.sql
+++ b/models/staging/complete_journey/stg_complete_journey__transactions.sql
@@ -14,7 +14,7 @@ final as (
     select 
         transactions.household_id,
         transactions.basket_id,
-        transactions.day_number,
+        transactions.transaction_date,
         transactions.product_id,
         transactions.quantity,
         transactions.sales_value,


### PR DESCRIPTION
- Dates are relative to current date for duration of dataset
- Macro to calculate duration of demo period
- Will mean that demonstrations can run correctly based on relative dates